### PR TITLE
Wizard title Change and timestamp adjusted to local browser time

### DIFF
--- a/csc-cmo-ssapp/code/pages/review-order.html
+++ b/csc-cmo-ssapp/code/pages/review-order.html
@@ -69,7 +69,7 @@
           <!-- Line -->
           <div class="step-break-line"></div>
           <!-- Confirmation -->
-          <div class="step-element" data-tag="step-4" id="step-4">4 - Confirmation</div>
+          <div class="step-element" data-tag="step-4" id="step-4">4 - Summary</div>
         </div>
 
         <!-- 1 - Order Details -->

--- a/csc-services/controllers/impl/DashboardControllerImpl.js
+++ b/csc-services/controllers/impl/DashboardControllerImpl.js
@@ -83,7 +83,7 @@ class DashboardControllerImpl extends WebcController {
 			keySSI: data.message.data.orderSSI,
 			role: notificationRole,
 			did: orderData.sponsorId,
-			date: new Date().toISOString()
+			date: new Date().toLocaleString()
 		};
 
 		const notificationResult = await this.notificationsService.insertNotification(notification);

--- a/csc-services/controllers/impl/ReviewOrderControllerImpl.js
+++ b/csc-services/controllers/impl/ReviewOrderControllerImpl.js
@@ -132,7 +132,7 @@ class ReviewOrderControllerImpl extends WebcController {
       keySSI: this.model.order.keySSI,
       role: this.role,
       did: this.model.order.sponsorId,
-      date: new Date().toISOString(),
+      date: new Date().toLocaleString(),
     };
 
     await this.notificationsService.insertNotification(notification);
@@ -251,7 +251,7 @@ class ReviewOrderControllerImpl extends WebcController {
           validated: false,
         },
         { id: 'step-3', holder_id: 'step-3-wrapper', name: 'Comments', visible: false, validated: false },
-        { id: 'step-4', holder_id: 'step-4-wrapper', name: 'Confirmation', visible: false, validated: false },
+        { id: 'step-4', holder_id: 'step-4-wrapper', name: 'Summary', visible: false, validated: false },
       ],
       wizard_form_navigation: [
         { id: 'from_step_1_to_2', name: 'Next', visible: true, validated: false },

--- a/csc-services/controllers/impl/SingleOrderControllerImpl.js
+++ b/csc-services/controllers/impl/SingleOrderControllerImpl.js
@@ -279,7 +279,7 @@ class SingleOrderControllerImpl extends WebcController {
             keySSI: this.model.order.keySSI,
             role: Roles.Sponsor,
             did: order.sponsorId,
-            date: new Date().toISOString(),
+            date: new Date().toLocaleString(),
           };
           await this.notificationsService.insertNotification(notification);
           eventBusService.emitEventListeners(Topics.RefreshNotifications, null);

--- a/csc-services/controllers/impl/SingleOrderControllerImpl.js
+++ b/csc-services/controllers/impl/SingleOrderControllerImpl.js
@@ -297,7 +297,7 @@ class SingleOrderControllerImpl extends WebcController {
             keySSI: this.model.order.keySSI,
             role: Roles.Sponsor,
             did: order.sponsorId,
-            date: new Date().toISOString(),
+            date: new Date().toLocaleString(),
           };
           await this.notificationsService.insertNotification(notification);
           eventBusService.emitEventListeners(Topics.RefreshNotifications, null);

--- a/csc-services/services/OrdersService.js
+++ b/csc-services/services/OrdersService.js
@@ -1,5 +1,6 @@
 const getSharedStorage = require('./lib/SharedDBStorageService.js').getSharedStorage;
 const DSUService = require('./lib/DSUService.js');
+const cscServices = require('csc-services');
 const { Roles, NotificationTypes, Topics, messagesEnum, order, FoldersEnum } = require('./constants');
 const orderStatusesEnum = order.orderStatusesEnum;
 const NotificationsService = require('./lib/NotificationService.js');
@@ -308,7 +309,7 @@ class OrdersService extends DSUService {
       keySSI: order.uid,
       role: Roles.Sponsor,
       did: '123-56',
-      date: new Date().toISOString(),
+      date: new Date().toLocaleString(),
     };
 
     const resultNotification = await this.notificationsService.insertNotification(notification);

--- a/csc-services/services/OrdersService.js
+++ b/csc-services/services/OrdersService.js
@@ -537,7 +537,6 @@ class OrdersService extends DSUService {
       comments = await this.addCommentToDsu(comment, orderDB.commentsKeySSI);
       orderDB.comments = comments.comments;
     }
-    orderDB.lastModified = new Date().getTime();
     const result = await this.updateOrderToDB(orderDB, orderKeySSI);
 
     let operation;
@@ -628,7 +627,6 @@ class OrdersService extends DSUService {
         }
         break;
     }
-    orderDB.lastModified = new Date().getTime();
     const result = await this.updateOrderToDB(orderDB, orderKeySSI);
     return result;
   }

--- a/csc-services/services/OrdersService.js
+++ b/csc-services/services/OrdersService.js
@@ -1,6 +1,5 @@
 const getSharedStorage = require('./lib/SharedDBStorageService.js').getSharedStorage;
 const DSUService = require('./lib/DSUService.js');
-const cscServices = require('csc-services');
 const { Roles, NotificationTypes, Topics, messagesEnum, order, FoldersEnum } = require('./constants');
 const orderStatusesEnum = order.orderStatusesEnum;
 const NotificationsService = require('./lib/NotificationService.js');

--- a/csc-sponsor-ssapp/code/pages/newOrder.html
+++ b/csc-sponsor-ssapp/code/pages/newOrder.html
@@ -21,7 +21,7 @@
           <!-- Line -->
           <div class="step-break-line"></div>
           <!-- Confirmation -->
-          <div class="step-element" data-tag="step-4" id="step-4">4 - Confirmation</div>
+          <div class="step-element" data-tag="step-4" id="step-4">4 - Summary</div>
         </div>
 
         <!-- 1 - Order Details -->

--- a/csc-sponsor-ssapp/code/pages/review-order.html
+++ b/csc-sponsor-ssapp/code/pages/review-order.html
@@ -69,7 +69,7 @@
           <!-- Line -->
           <div class="step-break-line"></div>
           <!-- Confirmation -->
-          <div class="step-element" data-tag="step-4" id="step-4">4 - Confirmation</div>
+          <div class="step-element" data-tag="step-4" id="step-4">4 - Summary</div>
         </div>
 
         <!-- 1 - Order Details -->

--- a/csc-sponsor-ssapp/code/scripts/controllers/NewOrderController.js
+++ b/csc-sponsor-ssapp/code/scripts/controllers/NewOrderController.js
@@ -20,7 +20,7 @@ export default class NewOrderController extends WebcController {
         { id: 'step-1', holder_id: 'step-1-wrapper', name: 'Order Details', visible: true, validated: false },
         { id: 'step-2', holder_id: 'step-2-wrapper', name: 'Attach Documents', visible: false, validated: false },
         { id: 'step-3', holder_id: 'step-3-wrapper', name: 'Comments', visible: false, validated: false },
-        { id: 'step-4', holder_id: 'step-4-wrapper', name: 'Confirmation', visible: false, validated: false },
+        { id: 'step-4', holder_id: 'step-4-wrapper', name: 'Summary', visible: false, validated: false },
       ],
       wizard_form_navigation: [
         { id: 'from_step_1_to_2', name: 'Next', visible: true, validated: false },


### PR DESCRIPTION
Fix for bug #146 and #147
Timestamps are adjusted to the local (browser) time
SPONSOR, CMO: Change of the title in Wizard from "Confirmation" to "Summary".
Attached is snapshot
![image](https://user-images.githubusercontent.com/88542564/131838488-03d23831-03e9-41c6-a308-5a93d599da35.png)
