### PR TITLE
#464 - Wrong timestamp in the SPO Attached Documents rectified

### DIFF
--- a/csc-services/controllers/impl/SingleOrderControllerImpl.js
+++ b/csc-services/controllers/impl/SingleOrderControllerImpl.js
@@ -230,12 +230,6 @@ class SingleOrderControllerImpl extends WebcController {
     if (data) {
       data.documents = [];
 
-      if (data.sponsorDocuments) {
-        data.sponsorDocuments.forEach((item) => {
-          item.date = momentService(item.data).format(Commons.DateTimeFormatPattern);
-        });
-      }
-
       data.status_value = data.status.sort(function(a, b) {
         return new Date(b.date) - new Date(a.date);
       })[0].status;


### PR DESCRIPTION
Duplicate sponsorDocuments was written in transformOrderData function 